### PR TITLE
Fix for bug #5.

### DIFF
--- a/app/controllers/refinery/authentication/devise/sessions_controller.rb
+++ b/app/controllers/refinery/authentication/devise/sessions_controller.rb
@@ -7,6 +7,7 @@ module Refinery
 
         before_action :clear_unauthenticated_flash, :only => [:new]
         before_action :force_signup_when_no_users!
+        skip_before_action :detect_authentication_devise_user!, only: [:create]
         after_action :detect_authentication_devise_user!, only: [:create]
 
         def create


### PR DESCRIPTION
Devise will delete _csrf_token in subsequent calls of detect_authentication_devise_user and this will lead to "Can't verify CSRF..." during login.