### PR TITLE
Redirect to sign in page after sign out.

### DIFF
--- a/lib/refinery/authentication/devise/system.rb
+++ b/lib/refinery/authentication/devise/system.rb
@@ -52,7 +52,7 @@ module Refinery
         end
 
         def after_sign_out_path_for(resource_or_scope)
-          refinery.root_path
+          refinery.login_path
         end
 
         protected :store_location, :pop_stored_location, :redirect_back_or_default,

--- a/readme.md
+++ b/readme.md
@@ -7,5 +7,17 @@ This extension allows you to use Devise with Refinery CMS 3.0 and later.
 Simply put this in the Gemfile of your Refinery application:
 
 ```ruby
-gem 'refinerycms-authentication-devise', '~> 1.0.0'
+gem 'refinerycms-authentication-devise', '~> 1.0.2'
 ```
+
+## Contributing
+
+1. Fork and clone the repository
+2. Install the dependencies: `bundle install`
+3. Create the testing application: `bundle exec rake refinery:testing:dummy_app`
+4. Run the tests: `bin/rspec`
+5. Create your feature branch (`git checkout -b my-new-feature`)
+6. Make your changes. Add some specs.
+7. Commit your changes (`git commit -am 'Add some feature'`)
+8. Push to the branch (`git push -u origin my-new-feature`)
+9. Create new Pull Request

--- a/spec/features/refinery/authentication/devise/sessions_spec.rb
+++ b/spec/features/refinery/authentication/devise/sessions_spec.rb
@@ -101,3 +101,26 @@ describe 'redirects', :type => :feature do
   end
 
 end
+
+describe "sign out", :type => :feature do
+  before do
+    FactoryGirl.create(:authentication_devise_refinery_user,
+      :username => "ugisozols",
+      :password => "123456",
+      :password_confirmation => "123456"
+    )
+    visit refinery.login_path
+    fill_in "Username or email", :with => "ugisozols"
+    fill_in "Password", :with => "123456"
+    click_button "Sign in"
+  end
+
+  context "when I sign out" do
+    before { click_on "Log out" }
+
+    it "redirects me back to the sign in page" do
+      expect(current_path).to eq(refinery.login_path)
+      expect(page).to have_content("Signed out successfully")
+    end
+  end
+end


### PR DESCRIPTION
This PR changes the default sign out redirect so that you are redirected back to the sign in page. This naturally fixes an issue where the "signed out successfully" flash message was being displayed on the next visit to the sign in page (which could have been a long time since logging out).

I also added a test for sign out.

I also added some documentation to the readme for future contributors on how to get the dependencies installed in order to run the test suite.