### PR TITLE
docs: add upgrade instructions for pre-3.0 Refinery installs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,8 +7,29 @@ This extension allows you to use Devise with Refinery CMS 3.0 and later.
 Simply put this in the Gemfile of your Refinery application:
 
 ```ruby
-gem 'refinerycms-authentication-devise', '~> 1.0.2'
+gem 'refinerycms-authentication-devise', '~> 1.0.4'
 ```
+
+Then run `bundle install` to install it.
+
+## Installation
+
+If you're moving from a pre-3.0 release of Refinery, you lost authentication when it moved out of RefineryCMS core. After installing this gem, follow these steps to migrate old user data and re-enable authentication
+
+### Generate and run migrations
+
+```sh
+rails g refinery:authentication:devise  # Generate migrations
+rake db:migrate                         # Run migrations
+```
+
+### Set up your new initializer
+
+You might have old data in `initializers/refinery/authentication.rb`. The new initializer is located in `initializers/refinery/authentication/devise.rb`.
+
+Make sure `devise.rb` is configured correctly, then delete `authentication.rb`.
+
+Then restart your server.
 
 ## Contributing
 

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ Then run `bundle install` to install it.
 
 ## Installation
 
-If you're moving from a pre-3.0 release of Refinery, you lost authentication when it moved out of RefineryCMS core. After installing this gem, follow these steps to migrate old user data and re-enable authentication
+If you're moving from a pre-3.0 release of Refinery, you lost authentication when it moved out of RefineryCMS core. After installing this gem, follow these steps to migrate old user data and re-enable authentication.
 
 ### Generate and run migrations
 


### PR DESCRIPTION
I had trouble figuring out what needed to be done to move from pre-3.0 (bundled auth) to this gem (external auth). Hopefully these instructions help someone else.