### PR TITLE
Fix missing translations in 2 locales.

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,6 +54,8 @@ en:
         roles:
           superuser: Superuser
           refinery: Refinery
+        delete:
+          message: "Are you sure you want to permanently remove %{title} ?"
   devise:
     failure:
       unauthenticated: You need to sign in before continuing.

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -54,6 +54,8 @@ nl:
         roles:
           superuser: Beheerder
           refinery: Refinery-gebruiker
+        delete:
+          message: "Weet je zeker dat je %{title} definitief wil verwijderen ?"
   devise:
     failure:
       unauthenticated: U moet inloggen om verder te kunnen


### PR DESCRIPTION
Fixed a missing translation in EN & NL caused by this line: 

https://github.com/refinery/refinerycms-authentication-devise/blob/master/app/views/refinery/authentication/devise/admin/users/_form.html.erb#L82

Wasn't sure if a mistake was made in choosing the I18n key but couldn't find a suitable translation elsewhere in the en.yml file, which I assumed was the base file. 
