### PR TITLE
Fix search

### DIFF
--- a/app/models/refinery/authentication/devise/user.rb
+++ b/app/models/refinery/authentication/devise/user.rb
@@ -15,6 +15,8 @@ module Refinery
 
         friendly_id :username, use: [:slugged]
 
+        acts_as_indexed :fields => [:username, :email]
+
         # Include default devise modules. Others available are:
         # :token_authenticatable, :confirmable, :lockable and :timeoutable
         if self.respond_to?(:devise)


### PR DESCRIPTION
 - add acts_as_indexed to devise user model
 - I was getting this error: NoMethodError (undefined method `with_query' for
   #<Refinery::Authentication::Devise::User::ActiveRecord_Relation:0x007f542a4b5c78>)