### PR TITLE
Replace HABTMs with HMTs

### DIFF
--- a/app/models/refinery/authentication/devise/role.rb
+++ b/app/models/refinery/authentication/devise/role.rb
@@ -3,7 +3,8 @@ module Refinery
     module Devise
       class Role < Refinery::Core::BaseModel
 
-        has_and_belongs_to_many :users, :join_table => :refinery_authentication_devise_roles_users
+        has_many :roles_users, class_name: 'Refinery::Authentication::Devise::RolesUsers'
+        has_many :users, through: :roles_users, class_name: 'Refinery::Authentication::Devise::User'
 
         before_validation :camelize_title
         validates :title, :uniqueness => true

--- a/app/models/refinery/authentication/devise/user.rb
+++ b/app/models/refinery/authentication/devise/user.rb
@@ -8,7 +8,8 @@ module Refinery
 
         extend FriendlyId
 
-        has_and_belongs_to_many :roles, join_table: :refinery_authentication_devise_roles_users
+        has_many :roles_users, class_name: 'Refinery::Authentication::Devise::RolesUsers'
+        has_many :roles, through: :roles_users, class_name: 'Refinery::Authentication::Devise::Role'
 
         has_many :plugins, -> { order('position ASC') },
                            class_name: "Refinery::Authentication::Devise::UserPlugin", dependent: :destroy


### PR DESCRIPTION
I'm not able to `exclude_models` for `gem 'apartment'` if we use HABTMs instead of HMT: https://github.com/influitive/apartment#excluding-models

I get inspiration on this PR for Spree : https://github.com/spree/spree/pull/6627