### PR TITLE
Supporting Rails 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ notifications:
   webhooks:
     - https://webhooks.gitter.im/e/b5d48907cdc89864b874
 rvm:
-  - 2.2
-  - 2.1
-  - 2.0.0
+  - 2.4.1
+  - 2.3.3
+  - 2.2.6
 sudo: false

--- a/Gemfile
+++ b/Gemfile
@@ -36,10 +36,6 @@ group :assets do
   gem "uglifier"
 end
 
-group :development do
-  gem 'quiet_assets'
-end
-
 group :test do
   gem "launchy"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,10 @@ source "https://rubygems.org"
 
 gemspec
 
-git "https://github.com/refinery/refinerycms", branch: "3-0-stable" do
+git "https://github.com/refinery/refinerycms", branch: "feature/rails-5" do
   gem "refinerycms"
+
+  gem "refinerycms-i18n", git: "https://github.com/refinery/refinerycms-i18n", branch: "feature/rails-5"
 
   group :test do
     gem "refinerycms-testing"

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 git "https://github.com/refinery/refinerycms", branch: "feature/rails-5" do
   gem "refinerycms"
 
-  gem "refinerycms-i18n", git: "https://github.com/refinery/refinerycms-i18n", branch: "feature/rails-5"
+  gem "refinerycms-i18n", git: "https://github.com/refinery/refinerycms-i18n", branch: "master"
 
   group :test do
     gem "refinerycms-testing"

--- a/app/controllers/refinery/authentication/devise/admin/users_controller.rb
+++ b/app/controllers/refinery/authentication/devise/admin/users_controller.rb
@@ -48,7 +48,7 @@ module Refinery
             store_user_memento
 
             @user.roles = @selected_role_names.map { |r| Refinery::Authentication::Devise::Role[r.downcase] }
-            if @user.update_attributes user_params
+            if @user.update_attributes user_params.to_h
               update_successful
             else
               update_failed
@@ -106,7 +106,7 @@ module Refinery
           private
           def exclude_password_assignment_when_blank!
             if params[:user][:password].blank? && params[:user][:password_confirmation].blank?
-              params[:user].except!(:password, :password_confirmation)
+              params[:user].extract!(:password, :password_confirmation)
             end
           end
 

--- a/app/controllers/refinery/authentication/devise/sessions_controller.rb
+++ b/app/controllers/refinery/authentication/devise/sessions_controller.rb
@@ -7,7 +7,7 @@ module Refinery
 
         before_action :clear_unauthenticated_flash, :only => [:new]
         before_action :force_signup_when_no_users!
-        skip_before_action :detect_authentication_devise_user!, only: [:create]
+        skip_before_action :detect_authentication_devise_user!, only: [:create], raise: false
         after_action :detect_authentication_devise_user!, only: [:create]
 
         def create

--- a/refinerycms-authentication-devise.gemspec
+++ b/refinerycms-authentication-devise.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.test_files        = `git ls-files -- spec/*`.split("\n")
 
   s.add_dependency 'refinerycms-core',  ['>= 3.0.0', '< 5.0']
-  s.add_dependency 'actionmailer',      ['>= 5.0.0', '< 5.1']
+  s.add_dependency 'actionmailer',      ['>= 5.0.0', '< 5.2']
   s.add_dependency 'devise',            ['~> 4.0', '>= 4.3.0']
   s.add_dependency 'friendly_id',       '~> 5.2.1'
 

--- a/refinerycms-authentication-devise.gemspec
+++ b/refinerycms-authentication-devise.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'refinerycms-core',  ['>= 3.0.0', '< 5.0']
   s.add_dependency 'actionmailer',      ['>= 5.0.0', '< 5.1']
   s.add_dependency 'devise',            ['~> 4.0', '>= 4.3.0']
-  s.add_dependency 'friendly_id',       '~> 5.1.0'
+  s.add_dependency 'friendly_id',       '~> 5.2.1'
 
   s.required_ruby_version = '>= 2.0.0'
 end

--- a/refinerycms-authentication-devise.gemspec
+++ b/refinerycms-authentication-devise.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |s|
   s.test_files        = `git ls-files -- spec/*`.split("\n")
 
   s.add_dependency 'refinerycms-core',  ['>= 3.0.0', '< 5.0']
-  s.add_dependency 'actionmailer',      ['~> 4.2', '>= 4.2.0']
-  s.add_dependency 'devise',            ['~> 3.0', '>= 3.2.4']
+  s.add_dependency 'actionmailer',      ['>= 5.0.0', '< 5.1']
+  s.add_dependency 'devise',            ['~> 4.0', '>= 4.3.0']
   s.add_dependency 'friendly_id',       '~> 5.1.0'
 
   s.required_ruby_version = '>= 2.0.0'

--- a/spec/controllers/refinery/authentication/devise/admin/users_controller_spec.rb
+++ b/spec/controllers/refinery/authentication/devise/admin/users_controller_spec.rb
@@ -34,7 +34,7 @@ describe Refinery::Authentication::Devise::Admin::UsersController, :type => :con
       user = Refinery::Authentication::Devise::User.new :username => "bob"
       expect(user).to receive(:save).once{ true }
       expect(Refinery::Authentication::Devise::User).to receive(:new).once.with(instance_of(ActionController::Parameters)){ user }
-      post :create, :user => {:username => 'bobby'}
+      post :create, params: { user: { username: 'bobby' } }
       expect(response).to be_redirect
     end
 
@@ -44,7 +44,7 @@ describe Refinery::Authentication::Devise::Admin::UsersController, :type => :con
       user = Refinery::Authentication::Devise::User.new :username => "bob"
       expect(user).to receive(:save).once{ false }
       expect(Refinery::Authentication::Devise::User).to receive(:new).once.with(instance_of(ActionController::Parameters)){ user }
-      post :create, :user => {:username => 'bobby'}
+      post :create, params: { user: { username: 'bobby' } }
       expect(response).to be_success
       expect(response).to render_template("refinery/authentication/devise/admin/users/new")
     end
@@ -54,7 +54,7 @@ describe Refinery::Authentication::Devise::Admin::UsersController, :type => :con
     refinery_login_with_devise [:refinery, :superuser]
 
     it "renders the edit template" do
-      get :edit, :id => logged_in_user.id
+      get :edit, params: { id: logged_in_user.id }
       expect(response).to be_success
       expect(response).to render_template("refinery/authentication/devise/admin/users/edit")
     end
@@ -67,13 +67,13 @@ describe Refinery::Authentication::Devise::Admin::UsersController, :type => :con
 
     let(:additional_user) { FactoryGirl.create :authentication_devise_refinery_user }
     it "updates a user" do
-      patch "update", :id => additional_user.id.to_s, :user => {:username => 'bobby'}
+      patch :update, params: { id: additional_user.id.to_s, user: { username: 'bobby' } }
       expect(response).to be_redirect
     end
 
     context "when specifying plugins" do
       it "won't allow to remove 'Users' plugin from self" do
-        patch "update", :id => logged_in_user.id.to_s, :user => {:plugins => ["some plugin"]}
+        patch :update, params: { id: logged_in_user.id.to_s, user: { plugins: ["some plugin"] } }
 
         expect(flash[:error]).to eq("You cannot remove the 'Users' plugin from the currently logged in account.")
       end
@@ -81,7 +81,7 @@ describe Refinery::Authentication::Devise::Admin::UsersController, :type => :con
       it "will update to the plugins supplied" do
         expect(logged_in_user).to receive(:update_attributes).with({"plugins" => %w(refinery_authentication_devise some_plugin)})
         allow(Refinery::Authentication::Devise::User).to receive_message_chain(:includes, :find) { logged_in_user }
-        patch "update", :id => logged_in_user.id.to_s, :user => {:plugins => %w(refinery_authentication_devise some_plugin)}
+        patch :update, params: { id: logged_in_user.id.to_s, user: { plugins: %w(refinery_authentication_devise some_plugin) } }
       end
     end
 

--- a/spec/support/refinery/authentication/devise/controller_macros.rb
+++ b/spec/support/refinery/authentication/devise/controller_macros.rb
@@ -3,7 +3,7 @@ module Refinery
     module Devise
       module ControllerMacros
         def self.extended(base)
-          base.send :include, ::Devise::TestHelpers
+          base.send :include, ::Devise::Test::ControllerHelpers
         end
 
         def refinery_login_with_devise(*roles)


### PR DESCRIPTION
Dear Refinery community 😄 ,

I've been busy with updating this gem, so the authentication will also work with Rails 5. This PR is currently using the `feature/rails-5` branch for the dependencies `refinerycms` and `refinerycms-i18n`. 

I've replaced `except!` with `extract!`, because `except!` will be deprecated in Rails 5.1. This function can be replaced with `extract!`, because we're only removing the `:password` and the `password_confirmation` in `exclude_password_assignment_when_blank!` from the user params. 

The feature spec https://github.com/refinery/refinerycms-authentication-devise/blob/master/spec/features/refinery/authentication/devise/sessions_spec.rb#L119 will probably fail. This is caused by the new RefineryCMS UI, which is only less than half implemented. Maybe it's an idea that we'll remove this UI, because it's been 1,5 year and the UI isn't still fully implemented in Refinery? I'll create a special PR for this in the RefineryCMS gem, so you guys may make a call about it. 