### PR TITLE
Traverse up an additional level when defining root path

### DIFF
--- a/lib/refinery/authentication/devise.rb
+++ b/lib/refinery/authentication/devise.rb
@@ -19,7 +19,7 @@ module Refinery
         end
 
         def root
-          @root ||= Pathname.new(File.expand_path('../../../', __FILE__))
+          @root ||= Pathname.new(File.expand_path('../../../../', __FILE__))
         end
       end
     end

--- a/spec/lib/refinery/authentication/devise/path_helpers_spec.rb
+++ b/spec/lib/refinery/authentication/devise/path_helpers_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+module Refinery
+  module Authentication
+    module Devise
+      describe 'path helpers' do
+        describe '.root' do
+          it 'contains the gemspec' do
+            root_path = Refinery::Authentication::Devise.root
+            gemspec_path = File.join(root_path, 'refinerycms-authentication-devise.gemspec')
+            expect(File.exist?(gemspec_path)).to eq true
+          end
+        end
+
+        describe '.factory_paths' do
+          it 'has directories that exist' do
+            factories_dir = Refinery::Authentication::Devise.factory_paths
+            expect(factories_dir.all? { |factory_path| Dir.exist?(factory_path) })
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
HI @joshmcarthur, let me open this PR for you it will be easier for us to follow this bugfix. I will wait for your regression test. Thanks ! 

>  I suspect the `Refinery:Authentication::Devise#root` method is either generated or copy-pasted from another plugin. Normally, a plugin would define the `root` and `factory_paths` methods in `lib/refinery/plugin_name.rb`, however this particular plugin is nested in under `authentication`, meaning that the root path is actually a directory higher than usual.