### PR TITLE
Add Ruby 2.5.0 to Travis Ruby build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ notifications:
   webhooks:
     - https://webhooks.gitter.im/e/b5d48907cdc89864b874
 rvm:
+  - 2.5.0
   - 2.4.1
   - 2.3.3
   - 2.2.6


### PR DESCRIPTION
While working on https://github.com/refinery/refinerycms-authentication-devise/pull/36, I worked within a Docker image based on Ruby 2.5, and was able to run the tests without any failures.

To ensure that this library continues to support Ruby 2.5.0, I recommend adding it to the Rubies that Travis will run tests against.